### PR TITLE
chore(workflow): reintroduce kv bindings setup

### DIFF
--- a/functions/maintenance/index.ts
+++ b/functions/maintenance/index.ts
@@ -1,0 +1,11 @@
+interface Env {
+  maintenance_mode: KVNamespace
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  console.log(
+    `[LOGGING FROM /maintenance]: Request came from ${context.request.url}`
+  )
+  const res = await context.env.maintenance_mode.get("is_active")
+  return new Response(res)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
       },
       "devDependencies": {
         "@cloudflare/next-on-pages": "^1.13.8",
+        "@cloudflare/workers-types": "^4.20250303.0",
         "@commitlint/config-conventional": "^19.7.1",
         "@testing-library/jest-dom": "^6.1.5",
         "@testing-library/react": "^14.3.1",
@@ -666,6 +667,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20250303.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250303.0.tgz",
+      "integrity": "sha512-O7F7nRT4bbmwHf3gkRBLfJ7R6vHIJ/oZzWdby6obOiw2yavUfp/AIwS7aO2POu5Cv8+h3TXS3oHs3kKCZLraUA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@commitlint/cli": {
       "version": "19.7.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@cloudflare/next-on-pages": "^1.13.8",
+    "@cloudflare/workers-types": "^4.20250303.0",
     "@commitlint/config-conventional": "^19.7.1",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.3.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["@cloudflare/workers-types"],
     "allowJs": true,
     "target": "ES6",
     "skipLibCheck": true,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,5 +6,11 @@
   "pages_build_output_dir": ".vercel/output/static",
   "observability": {
     "enabled": true
-  }
+  },
+  "kv_namespaces": [
+    {
+      "binding": "maintenance_mode",
+      "id": "b45ec1d38ea64690890ebebd07e36671"
+    }
+  ]
 }


### PR DESCRIPTION
### Summary

This PR reintroduces the **Cloudflare KV bindings setup** to properly manage maintenance mode functionality in the app. It includes the necessary `functions`, type declarations, and KV configuration.

---

### Changes Included

#### 1. **New Pages Function for Maintenance Mode Check**

> **File**: `functions/maintenance/index.ts`

```ts
interface Env {
  maintenance_mode: KVNamespace;
}

export const onRequestGet: PagesFunction<Env> = async (context) => {
  console.log(
    `[LOGGING FROM /maintenance]: Request came from ${context.request.url}`
  );
  const res = await context.env.maintenance_mode.get("is_active");
  return new Response(res);
};
```

- Adds a `GET /maintenance` route for checking maintenance mode.
- Logs requests for debugging.
- Fetches `is_active` flag from the `maintenance_mode` KV store.

---

#### 2. **Cloudflare Workers Types**

> **Files**: `package.json`, `package-lock.json`

```json
"@cloudflare/workers-types": "^4.20250303.0"
```

- Adds Cloudflare Workers types for proper type-checking and DX.

---

#### 3. **TypeScript Config Updates**

> **File**: `tsconfig.json`

```json
"types": ["@cloudflare/workers-types"]
```

- Ensures types are included during build and development.

---

#### 4. **Wrangler KV Namespace Binding**

> **File**: `wrangler.jsonc`

```jsonc
"kv_namespaces": [
  {
    "binding": "maintenance_mode",
    "id": "b45ec1d38ea64690890ebebd07e36671"
  }
]
```

- Binds the KV namespace `maintenance_mode` with its ID for use in functions.

---

### Purpose

- Enable feature flag-style **maintenance mode handling** via KV.
- Improve developer experience with proper type definitions.
- Prepare the app for future dynamic maintenance toggles via KV.

---

### Testing

- [x] Verified `/maintenance` route is callable and responds with KV value.
- [x] Confirmed logs appear for each request to `/maintenance`.
- [x] Validated KV namespace binding via `wrangler pages dev --kv=maintenance_mode`.