### PR TITLE
Fetch Mobile Maintenance Mode from API in Maintenance Dialog

### DIFF
--- a/app/api/maintenance/route.ts
+++ b/app/api/maintenance/route.ts
@@ -5,5 +5,5 @@ export const runtime = "edge"
 export async function GET() {
   const KV = getRequestContext().env.maintenance_mode
   const isActive = await KV.get("is_active")
-  return new Response(`is_active: ${isActive}!`)
+  return new Response(isActive)
 }

--- a/components/mobile-maintenance-dialog.tsx
+++ b/components/mobile-maintenance-dialog.tsx
@@ -9,10 +9,32 @@ import {
 } from "@/components/ui/dialog"
 import { useMobileDetection } from "@/hooks/use-mobile-detection"
 import { AlertTriangle } from "lucide-react"
+import { useState, useEffect } from "react"
 
 export function MobileMaintenanceDialog() {
   const { isMobile, isReady } = useMobileDetection()
-  const maintenanceMode = true
+
+  const [maintenanceMode, setMaintenanceMode] = useState(false)
+
+  useEffect(() => {
+    async function fetchMaintenanceMode() {
+      try {
+        const res = await fetch("/api/maintenance")
+
+        if (res.ok) {
+          const isActive = await res.text()
+          setMaintenanceMode(isActive === "true")
+        } else {
+          console.error('[ERROR] fetch("/api/maintenance")')
+        }
+      } catch (error) {
+        console.error('[ERROR] fetch("/api/maintenance")', error)
+      }
+    }
+
+    fetchMaintenanceMode()
+  }, [])
+
   const showDialog = isReady && isMobile && maintenanceMode
 
   if (!showDialog) return null


### PR DESCRIPTION
This PR updates the `MobileMaintenanceDialog` component to dynamically fetch the mobile maintenance mode status from the `/api/maintenance` endpoint instead of relying on a static flag. This improves flexibility and allows enabling/disabling mobile maintenance mode without code changes or redeployments.

### Changes  
- Integrated `fetch("/api/maintenance")` to check if mobile maintenance mode is active.  
- Ensured the dialog is shown only when mobile detection is ready, the user is on a mobile device, and maintenance mode is active.  
- Added error handling for failed API calls.  

### Related  
Resolves part of the effort to manage mobile access dynamically.