### PR TITLE
Dynamic Docs Invalidation in Workflow

### DIFF
--- a/.github/workflows/invalidate-docs.yml
+++ b/.github/workflows/invalidate-docs.yml
@@ -12,9 +12,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract changed doc files
+        id: changed_docs
+        run: |
+          DOCS=$(git diff --name-only HEAD^ HEAD \
+            | grep '^public/docs/' \
+            | sed 's|public/docs/||' \
+            | sed 's|\.md||' \
+            | tr '[:upper:]' '[:lower:]' \
+            | tr '\n' ' ')
+          echo "CHANGED_DOCS=$DOCS" >> $GITHUB_ENV
+
       - name: Call Cache Invalidation API
         run: |
-          curl -X POST "https://yourdomain.com/api/docs?doc=policy"
-          curl -X POST "https://yourdomain.com/api/docs?doc=terms"
+          for doc in $CHANGED_DOCS; do
+            curl -X POST "https://instaplanner.pages.dev/api/docs/$doc"
+          done
         env:
           API_SECRET: ${{ secrets.KV_INVALIDATION_SECRET }}


### PR DESCRIPTION
#### **Summary**  
Updated `.github/workflows/invalidate-docs.yml` to dynamically extract and invalidate changed Markdown files instead of hardcoding API calls.  

#### **Changes**  
- Extracts changed doc files from `git diff`.  
- Converts filenames to lowercase and removes extensions.  
- Calls the invalidation API dynamically based on changed files.  

#### **Why?**  
- Improves maintainability by avoiding manual updates when new docs are added.  
- Ensures only modified docs are invalidated, optimizing API calls.  

#### **Testing**  
- Verified `git diff` correctly extracts changed docs.  
- Ensured API calls are dynamically generated and formatted correctly.  

#### **Checklist**  
- [x] Workflow runs successfully  
- [x] Extracted docs match expected format  
- [x] API calls are dynamically generated  